### PR TITLE
Missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,11 @@
 {
-	"name": "masterpass/mpasscoresdk",
-	"version": "2.0.0",
-	"description": "PHP Core SDK for use with Masterpass Merchant Checkout Service SDK on MasterCard Developer Zone",
-	"homepage": "https://developer.mastercard.com",
-	"require": {
-		"php": ">=5.5.0"
-	}
+  "name": "masterpass/mpasscoresdk",
+  "version": "2.0.0",
+  "description": "PHP Core SDK for use with Masterpass Merchant Checkout Service SDK on MasterCard Developer Zone",
+  "homepage": "https://developer.mastercard.com",
+  "require": {
+    "php": ">=5.5.0",
+    "guzzlehttp/guzzle": "6.0.0",
+    "pear/xml_parser": "1.3.7"
+  }
 }


### PR DESCRIPTION
Per the documentation available [here][doc] and searches with `ag`, it seems as though `guzzlehttp/guzzle` and `pear/xml_parser` are dependencies, but were not listed as such in `composer.json`.

This PR adds the missing dependencies to `composer.json`, and also includes a `.gitignore` file to exclude the `vendor` directory and `composer.lock` file.

[doc]: https://developer.mastercard.com/documentation/masterpass-merchant-integration#php